### PR TITLE
Updated GH and readthedocs actions workflow

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           generate-run-shell: true
           environment-file: environment.yml
+
       - name: Install floatCSEP
         run: |
           pip install -e .[dev]

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -15,18 +15,14 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
       - uses: mamba-org/setup-micromamba@v1
         with:
           generate-run-shell: true
           environment-file: environment.yml
-          create-args: >-
-            python=${{ matrix.python-version }}
-
       - name: Install floatCSEP
         run: |
-          pip install -r requirements_dev.txt
-          pip install --no-deps -e .
+          pip install -e .[dev]
           python -c "import floatcsep; print('Version: ', floatcsep.__version__)"
 
       - name: Build documentation

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4.2.2
     - uses: mamba-org/setup-micromamba@v1
       with:
         generate-run-shell: true
@@ -32,15 +32,16 @@ jobs:
 
     - name: Install floatCSEP
       run: |
-        pip install pytest pytest-cov vcrpy==4.3.1
-        pip install --no-deps -e .
+        pip install -e .[dev]
         python -c "import floatcsep; print('Version: ', floatcsep.__version__)"
 
     - name: Test with pytest
       run: |
-        pytest --durations=0 --cov=./ --cov-config=.coveragerc
+        pytest --durations=0
 
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
-      run: |
-        bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }} 
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,6 @@ jobs:
         create-args: >-
           python=${{ matrix.python-version }}
 
-
     - name: Install floatCSEP
       run: |
         pip install -e .[dev]

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
       - uses: mamba-org/setup-micromamba@v1
         with:
           generate-run-shell: true
@@ -25,14 +25,19 @@ jobs:
 
       - name: Install py-build and setuptools-scm
         run: |
-          micromamba run -n floatcsep python3 -m pip install --upgrade build setuptools-scm
+          micromamba run -n floatcsep pip install --upgrade build setuptools-scm
 
       - name: Build
         run: |
           micromamba run -n floatcsep python3 -m build --sdist --wheel --outdir dist/
 
+      - name: Check distribution files
+        run: |
+          micromamba run -n floatcsep pip install twine
+          micromamba run -n floatcsep twine check dist/*
+
       - name: Publish Package
-        uses: pypa/gh-action-pypi-publish@v1.9.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-tutorials.yml
+++ b/.github/workflows/release-tutorials.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
 
       - name: Zip the tutorials folder
         run: |
           zip -r tutorials.zip tutorials/
 
       - name: Upload the tutorials.zip to the release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.2.2
         with:
           files: tutorials.zip
         env:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-22.9"
 
 conda:
   environment: environment.yml
@@ -12,5 +12,9 @@ python:
   install:
     - method: pip
       path: .
-    - method: pip
-      path: .[dev]  # Install development dependencies via pip
+      extra_requirements:
+        - dev
+      editable: true
+
+sphinx:
+  configuration: docs/conf.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -32,5 +32,5 @@ sphinx-toolbox
 sphinx_copybutton
 tables
 tox
-vcrpy==4.3.1
+vcrpy
 xmltodict

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ dev =
     sphinx_copybutton
     tables
     tox
-    vcrpy==4.3.1
+    vcrpy
     xmltodict
 
 [options.entry_points]


### PR DESCRIPTION
closes #48 


build: Removed pinned version of vcrpy. Updated and pinned versions of actions/checkout for all GH actions. Cleaned unnecessary matrix for sphinx. Uploaded installing of floatcsep in actions. Updated  secrets access for coverage. Added check with twine for release pypi

docs: Updated readthedocs.yaml to indicate sphinx config and properly build floatcsep.