### PR TITLE
Update management of input files

### DIFF
--- a/floatcsep/experiment.py
+++ b/floatcsep/experiment.py
@@ -175,7 +175,7 @@ class Experiment:
         Override built-in method to return the experiment attributes by also using the command
         ``experiment.{attr}``. Adds also to the experiment scope the keys of
         :attr:`region_config` or :attr:`time_config`. These are: ``start_date``, ``end_date``,
-        ``timewindows``, ``horizon``, ``offset``, ``region``, ``magnitudes``, ``mag_min``,
+        ``time_windows``, ``horizon``, ``offset``, ``region``, ``magnitudes``, ``mag_min``,
         `mag_max``, ``mag_bin``, ``depth_min`` depth_max .
         """
 

--- a/floatcsep/infrastructure/repositories.py
+++ b/floatcsep/infrastructure/repositories.py
@@ -13,7 +13,7 @@ from csep.models import EvaluationResult
 from csep.utils.time_utils import decimal_year
 
 from floatcsep.utils.readers import ForecastParsers
-from floatcsep.infrastructure.registries import ForecastRegistry, ExperimentRegistry
+from floatcsep.infrastructure.registries import ExperimentRegistry, ModelRegistry
 from floatcsep.utils.helpers import str2timewindow, parse_csep_func
 from floatcsep.utils.helpers import timewindow2str
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class ForecastRepository(ABC):
 
     @abstractmethod
-    def __init__(self, registry: ForecastRegistry):
+    def __init__(self, registry: ModelRegistry):
         self.registry = registry
         self.lazy_load = False
         self.forecasts = {}
@@ -61,7 +61,7 @@ class ForecastRepository(ABC):
 
     @classmethod
     def factory(
-        cls, registry: ForecastRegistry, model_class: str, forecast_type: str = None, **kwargs
+        cls, registry: ModelRegistry, model_class: str, forecast_type: str = None, **kwargs
     ) -> "ForecastRepository":
         """Factory method. Instantiate first on explicit option provided in the model
         configuration. Then, defaults to gridded forecast for TimeIndependentModel and catalog
@@ -89,11 +89,11 @@ class CatalogForecastRepository(ForecastRepository):
 
     """
 
-    def __init__(self, registry: ForecastRegistry, **kwargs):
+    def __init__(self, registry: ModelRegistry, **kwargs):
         """
 
         Args:
-            registry (ForecastRegistry): The registry containing the keys/path to the forecasts
+            registry (ModelRegistry): The registry containing the keys/path to the forecasts
              given their time-windows.
             **kwargs:
         """
@@ -120,7 +120,7 @@ class CatalogForecastRepository(ForecastRepository):
             return [self._load_single_forecast(t, region) for t in tstring]
 
     def _load_single_forecast(self, t: str, region=None):
-        fc_path = self.registry.get_forecast(t)
+        fc_path = self.registry.get_forecast_key(t)
         return csep.load_catalog_forecast(
             fc_path, region=region, apply_filters=True, filter_spatial=True
         )
@@ -136,11 +136,11 @@ class GriddedForecastRepository(ForecastRepository):
     avoid parsing files repeatedly (Skip for large files).
 
     """
-    def __init__(self, registry: ForecastRegistry, **kwargs):
+    def __init__(self, registry: ModelRegistry, **kwargs):
         """
 
         Args:
-            registry (ForecastRegistry): The registry containing the keys/path to the forecasts
+            registry (ModelRegistry): The registry containing the keys/path to the forecasts
              given their time-windows.
             **kwargs:
         """
@@ -189,7 +189,7 @@ class GriddedForecastRepository(ForecastRepository):
         time_horizon = decimal_year(end_date) - decimal_year(start_date)
         tstring_ = timewindow2str([start_date, end_date])
 
-        f_path = self.registry.get_forecast(tstring_)
+        f_path = self.registry.get_forecast_key(tstring_)
         f_parser = getattr(ForecastParsers, self.registry.fmt)
 
         rates, region, mags = f_parser(f_path)
@@ -504,4 +504,4 @@ class CatalogRepository:
         """
         start, end = str2timewindow(tstring)
         sub_cat = self.catalog.filter([f"origin_time < {start.timestamp() * 1000}"])
-        sub_cat.write_ascii(filename=model.registry.get("input_cat"))
+        sub_cat.write_ascii(filename=model.registry.get_input_catalog_key())

--- a/tests/integration/test_model_accessors.py
+++ b/tests/integration/test_model_accessors.py
@@ -113,7 +113,7 @@ class TestModelFromGit(TestCase):
         return model
 
     @patch.object(EnvironmentManager, "create_environment")
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_from_git(self, mock_build_tree, mock_create_environment):
         """clones model from git, checks with test artifacts"""
         mock_build_tree.return_value = None
@@ -169,7 +169,7 @@ class TestModelFromZenodo(TestCase):
         model = TimeIndependentModel(name=name, model_path=model_path, **kwargs)
         return model
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_zenodo(self, mock_buildtree):
         """downloads model from zenodo, checks with test artifacts"""
         mock_buildtree.return_value = None
@@ -194,11 +194,11 @@ class TestModelFromZenodo(TestCase):
         model_b.stage()
 
         self.assertEqual(
-            os.path.basename(model_a.registry.get("path")),
-            os.path.basename(model_b.registry.get("path")),
+            os.path.basename(model_a.registry.get_attr("path")),
+            os.path.basename(model_b.registry.get_attr("path")),
         )
         self.assertEqual(model_a.name, model_b.name)
-        self.assertTrue(filecmp.cmp(model_a.registry.get("path"), model_b.registry.get("path")))
+        self.assertTrue(filecmp.cmp(model_a.registry.get_attr("path"), model_b.registry.get_attr("path")))
 
     def test_zenodo_fail(self):
         name = "mock_zenodo"

--- a/tests/integration/test_model_docker.py
+++ b/tests/integration/test_model_docker.py
@@ -78,20 +78,20 @@ class TestModelDockerIntegration(unittest.TestCase):
             workdir=str(model_dir),
         )
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_valid_model(self, mock_registry):
         model = self._make_model("valid", "testdocker_valid")
         model.stage()
         model.environment.run_command()  # Should succeed with no exceptions
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_invalid_image_build_fails(self, mock_registry):
         model = self._make_model("invalid_image", "testdocker_invalid_image")
         with self.assertRaises(RuntimeError) as err:
             model.environment.create_environment(force=True)
         self.assertIn("Docker build error", str(err.exception))
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_invalid_entrypoint_fails_to_run(self, mock_registry):
         model = self._make_model("invalid_entrypoint", "testdocker_invalid_entrypoint")
         model.stage()
@@ -99,7 +99,7 @@ class TestModelDockerIntegration(unittest.TestCase):
             model.environment.run_command()
         self.assertIn("exited with code", str(err.exception))
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_invalid_permission_fails_to_run(self, mock_registry):
         model = self._make_model("invalid_permission", "testdocker_invalid_permission")
         model.stage()
@@ -107,7 +107,7 @@ class TestModelDockerIntegration(unittest.TestCase):
             model.environment.run_command()
         self.assertIn("exited with code", str(err.exception))
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_valid_custom_uid_gid(self, mock_registry):
         # todo: look into it
         model = self._make_model("valid_custom_uid-gid", "testdocker_uid_gid")

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -41,6 +41,7 @@ class TestExperiment(TestCase):
         self.assertEqual(exp_a.registry.workdir, os.getcwd())
         self.assertEqual(exp_a.registry.workdir, exp_b.registry.workdir)
         self.assertEqual(exp_a.start_date, exp_b.start_date)
+        print(exp_a.timewindows, exp_b.timewindows)
         self.assertEqual(exp_a.timewindows, exp_b.timewindows)
         self.assertEqual(exp_a.exp_class, exp_b.exp_class)
         self.assertEqual(exp_a.region, exp_b.region)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2,7 +2,7 @@ import os.path
 from unittest import TestCase
 
 from floatcsep.model import TimeIndependentModel
-from floatcsep.infrastructure.registries import ForecastRegistry
+from floatcsep.infrastructure.registries import ModelRegistry
 from floatcsep.infrastructure.repositories import GriddedForecastRepository
 from unittest.mock import patch, MagicMock, mock_open
 from floatcsep.model import TimeDependentModel
@@ -27,7 +27,7 @@ class TestModel(TestCase):
             raise AssertionError("Models are not equal")
 
         for i in keys_a:
-            if isinstance(getattr(model_a, i), ForecastRegistry):
+            if isinstance(getattr(model_a, i), ModelRegistry):
                 continue
             if not (getattr(model_a, i) == getattr(model_b, i)):
                 print(getattr(model_a, i), getattr(model_b, i))
@@ -59,7 +59,7 @@ class TestTimeIndependentModel(TestModel):
 
     @patch("os.makedirs")
     @patch("floatcsep.model.TimeIndependentModel.get_source")
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry.build_tree")
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry.build_tree")
     def test_stage_creates_directory(self, mock_build_tree, mock_get_source, mock_makedirs):
         """Test stage method creates directory."""
         model = self.init_model("mock", "mockfile.csv")
@@ -159,7 +159,7 @@ class TestTimeDependentModel(TestModel):
 
     def setUp(self):
         # Patches
-        self.patcher_registry = patch("floatcsep.model.ForecastRegistry")
+        self.patcher_registry = patch("floatcsep.model.ModelFileRegistry")
         self.patcher_repository = patch("floatcsep.model.ForecastRepository.factory")
         self.patcher_environment = patch("floatcsep.model.EnvironmentFactory.get_env")
         self.patcher_get_source = patch(
@@ -185,7 +185,7 @@ class TestTimeDependentModel(TestModel):
         # Set attributes on the mock objects
         self.mock_registry_instance.workdir = "/path/to/workdir"
         self.mock_registry_instance.path = "/path/to/model"
-        self.mock_registry_instance.get.return_value = (
+        self.mock_registry_instance.get_args_key.return_value = (
             "/path/to/args_file.txt"  # Mocking the return of the registry call
         )
 
@@ -230,7 +230,7 @@ class TestTimeDependentModel(TestModel):
             self.model.zenodo_id, self.model.giturl, branch=self.model.repo_hash
         )
         self.mock_registry_instance.build_tree.assert_called_once_with(
-            timewindows=["2020-01-01_2020-12-31"],
+            time_windows=["2020-01-01_2020-12-31"],
             model_class="TimeDependentModel",
             prefix=self.model.__dict__.get("prefix", self.name),
             args_file=self.model.__dict__.get("args_file", None),
@@ -254,7 +254,7 @@ class TestTimeDependentModel(TestModel):
         self.model.create_forecast(tstring, force=True)
 
         self.mock_environment_instance.run_command.assert_called_once_with(
-            f'{self.func} {self.model.registry.get("args_file")}'
+            f'{self.func} {self.model.registry.get_args_key()}'
         )
 
     @patch("builtins.open", new_callable=mock_open)
@@ -279,7 +279,7 @@ class TestTimeDependentModel(TestModel):
         ]
 
         # Call the method
-        args_file_path = self.model.registry.get("args_file")
+        args_file_path = self.model.registry.get_args_key()
         self.model.prepare_args(start_date, end_date, custom_arg="value")
         mock_open_file.assert_any_call(args_file_path, "r")
         mock_open_file.assert_any_call(args_file_path, "w")
@@ -293,7 +293,7 @@ class TestTimeDependentModel(TestModel):
         )
 
         json_file_path = "/path/to/args_file.json"
-        self.model.registry.get.return_value = json_file_path
+        self.model.registry.get_args_key.return_value = json_file_path
         self.model.prepare_args(start_date, end_date, custom_arg="value")
 
         mock_open_file.assert_any_call(json_file_path, "r")

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,45 +1,45 @@
 import unittest
 from datetime import datetime
 from unittest.mock import patch, MagicMock
-from floatcsep.infrastructure.registries import ForecastRegistry
+from floatcsep.infrastructure.registries import ModelFileRegistry
 
 
-class TestForecastRegistry(unittest.TestCase):
+class TestModelFileRegistry(unittest.TestCase):
 
     def setUp(self):
-        self.registry_file = ForecastRegistry(
+        self.registry_for_filebased_model = ModelFileRegistry(
             workdir="/test/workdir", path="/test/workdir/model.txt"
         )
-        self.registry_folder = ForecastRegistry(
+        self.registry_for_folderbased_model = ModelFileRegistry(
             workdir="/test/workdir", path="/test/workdir/model"
         )
 
     def test_call(self):
-        self.registry_file._parse_arg = MagicMock(return_value="path")
-        result = self.registry_file.get("path")
+        self.registry_for_filebased_model._parse_arg = MagicMock(return_value="path")
+        result = self.registry_for_filebased_model.get_attr("path")
         self.assertEqual(result, "/test/workdir/model.txt")
 
     @patch("os.path.isdir")
     def test_dir(self, mock_isdir):
         mock_isdir.return_value = False
-        self.assertEqual(self.registry_file.dir, "/test/workdir")
+        self.assertEqual(self.registry_for_filebased_model.dir, "/test/workdir")
 
         mock_isdir.return_value = True
-        self.assertEqual(self.registry_folder.dir, "/test/workdir/model")
+        self.assertEqual(self.registry_for_folderbased_model.dir, "/test/workdir/model")
 
     def test_fmt(self):
-        self.registry_file.database = "test.db"
-        self.assertEqual(self.registry_file.fmt, "db")
-        self.registry_file.database = None
-        self.assertEqual(self.registry_file.fmt, "txt")
+        self.registry_for_filebased_model.database = "test.db"
+        self.assertEqual(self.registry_for_filebased_model.fmt, "db")
+        self.registry_for_filebased_model.database = None
+        self.assertEqual(self.registry_for_filebased_model.fmt, "txt")
 
     def test_parse_arg(self):
-        self.assertEqual(self.registry_file._parse_arg("arg"), "arg")
-        self.assertRaises(Exception, self.registry_file._parse_arg, 123)
+        self.assertEqual(self.registry_for_filebased_model._parse_arg("arg"), "arg")
+        self.assertRaises(Exception, self.registry_for_filebased_model._parse_arg, 123)
 
     def test_as_dict(self):
         self.assertEqual(
-            self.registry_file.as_dict(),
+            self.registry_for_filebased_model.as_dict(),
             {
                 "args_file": None,
                 "database": None,
@@ -51,28 +51,28 @@ class TestForecastRegistry(unittest.TestCase):
         )
 
     def test_abs(self):
-        result = self.registry_file.abs("file.txt")
+        result = self.registry_for_filebased_model.abs("file.txt")
         self.assertTrue(result.endswith("/test/workdir/file.txt"))
 
-    def test_absdir(self):
-        result = self.registry_file.abs_dir("model.txt")
+    def test_abs_dir(self):
+        result = self.registry_for_filebased_model.abs_dir("model.txt")
         self.assertTrue(result.endswith("/test/workdir"))
 
     @patch("floatcsep.infrastructure.registries.exists")
-    def test_fileexists(self, mock_exists):
+    def test_file_exists(self, mock_exists):
         mock_exists.return_value = True
-        self.registry_file.get = MagicMock(return_value="/test/path/file.txt")
-        self.assertTrue(self.registry_file.file_exists("file.txt"))
+        self.registry_for_filebased_model.get_attr = MagicMock(return_value="/test/path/file.txt")
+        self.assertTrue(self.registry_for_filebased_model.file_exists("file.txt"))
 
     @patch("os.makedirs")
     @patch("os.listdir")
     def test_build_tree_time_independent(self, mock_listdir, mock_makedirs):
         timewindows = [[datetime(2023, 1, 1), datetime(2023, 1, 2)]]
-        self.registry_file.build_tree(
-            timewindows=timewindows, model_class="TimeIndependentModel"
+        self.registry_for_filebased_model.build_tree(
+            time_windows=timewindows, model_class="TimeIndependentModel"
         )
-        self.assertIn("2023-01-01_2023-01-02", self.registry_file.forecasts)
-        # self.assertIn("2023-01-01_2023-01-02", self.registry_file.inventory)
+        self.assertIn("2023-01-01_2023-01-02", self.registry_for_filebased_model.forecasts)
+        # self.assertIn("2023-01-01_2023-01-02", self.registry_for_filebased_model.inventory)
 
     @patch("os.makedirs")
     @patch("os.listdir")
@@ -82,13 +82,13 @@ class TestForecastRegistry(unittest.TestCase):
             [datetime(2023, 1, 1), datetime(2023, 1, 2)],
             [datetime(2023, 1, 2), datetime(2023, 1, 3)],
         ]
-        self.registry_folder.build_tree(
-            timewindows=timewindows, model_class="TimeDependentModel", prefix="forecast"
+        self.registry_for_folderbased_model.build_tree(
+            time_windows=timewindows, model_class="TimeDependentModel", prefix="forecast"
         )
-        self.assertIn("2023-01-01_2023-01-02", self.registry_folder.forecasts)
-        # self.assertTrue(self.registry_folder.inventory["2023-01-01_2023-01-02"])
-        self.assertIn("2023-01-02_2023-01-03", self.registry_folder.forecasts)
-        # self.assertTrue(self.registry_folder.inventory["2023-01-02_2023-01-03"])
+        self.assertIn("2023-01-01_2023-01-02", self.registry_for_folderbased_model.forecasts)
+        # self.assertTrue(self.registry_for_folderbased_model.inventory["2023-01-01_2023-01-02"])
+        self.assertIn("2023-01-02_2023-01-03", self.registry_for_folderbased_model.forecasts)
+        # self.assertTrue(self.registry_for_folderbased_model.inventory["2023-01-02_2023-01-03"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch, PropertyMock, mock_open
 from csep.core.forecasts import GriddedForecast
 
 from floatcsep.utils.readers import ForecastParsers
-from floatcsep.infrastructure.registries import ForecastRegistry
+from floatcsep.infrastructure.registries import ModelFileRegistry
 from floatcsep.infrastructure.repositories import (
     CatalogForecastRepository,
     GriddedForecastRepository,
@@ -17,7 +17,7 @@ from floatcsep.infrastructure.repositories import (
 class TestCatalogForecastRepository(unittest.TestCase):
 
     def setUp(self):
-        self.registry = MagicMock(spec=ForecastRegistry)
+        self.registry = MagicMock(spec=ModelFileRegistry) #todo: Factory registry
         self.registry.__call__ = MagicMock(return_value="a_duck")
 
     @patch("csep.load_catalog_forecast")
@@ -48,7 +48,7 @@ class TestCatalogForecastRepository(unittest.TestCase):
 class TestGriddedForecastRepository(unittest.TestCase):
 
     def setUp(self):
-        self.registry = MagicMock(spec=ForecastRegistry)
+        self.registry = MagicMock(spec=ModelFileRegistry) #todo: Factory registry
         self.registry.fmt = "hdf5"
         self.registry.__call__ = MagicMock(return_value="a_duck")
 
@@ -138,10 +138,10 @@ class TestGriddedForecastRepository(unittest.TestCase):
             self.assertEqual(forecast, "forecatto")
             self.assertNotIn("2023-01-02_2023-01-03", repo.forecasts)
 
-    @patch("floatcsep.infrastructure.registries.ForecastRegistry")
-    def test_equal(self, MockForecastRegistry):
+    @patch("floatcsep.infrastructure.registries.ModelFileRegistry")
+    def test_equal(self, MockModelFileRegistry):
 
-        self.registry = MockForecastRegistry()
+        self.registry = MockModelFileRegistry()
 
         self.repo1 = CatalogForecastRepository(self.registry)
         self.repo2 = CatalogForecastRepository(self.registry)


### PR DESCRIPTION
refac: changed forecast registry abstraction. i) renamed to model reg…istry for clarity (ii) Registries' main job is to provide global access to Object keys (model forecasts, input catalog and arguments file), build the key structure (for instance, the path tree) and check if these objects already exists  (iii) current (ModelFileRegistry) and future (ModelHDF5Registry, ModelSQLRegistry) concrete classes are abstracted from ModelRegistry, which has the defined interface.