### PR TITLE
Improved report module

### DIFF
--- a/floatcsep/experiment.py
+++ b/floatcsep/experiment.py
@@ -394,7 +394,6 @@ class Experiment:
                     tstring=time_i,
                     models=self.models,
                 )
-                print("000")
                 task_graph.add(task=task_j)
 
         # Set up the Forecasts creation

--- a/floatcsep/model.py
+++ b/floatcsep/model.py
@@ -364,7 +364,7 @@ class TimeDependentModel(Model):
                 If None, will return a forecast for all regions.
 
         """
-        return self.repository.load_forecast(tstring, region=region)
+        return self.repository.load_forecast(tstring, name=self.name, region=region)
 
     def create_forecast(self, tstring: str, **kwargs) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "docker",
     "gitpython",
     "h5py",
+    "markdown-pdf",
     "matplotlib",
     "pandas",
     "packaging",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ dateparser
 docker
 gitpython
 h5py
+markdown-pdf
 matplotlib
 packaging
 pandas

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ flake8
 gitpython
 h5py
 matplotlib
+markdown-pdf
 packaging
 pandas
 pycsep

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -292,7 +292,7 @@ class TestTimeDependentModel(TestModel):
         self.model.get_forecast(tstring)
 
         self.mock_repository_instance.load_forecast.assert_called_once_with(
-            tstring, region=None
+            tstring, name=self.name, region=None
         )
 
     @patch("floatcsep.model.TimeDependentModel.prepare_args")

--- a/tests/unit/test_plot_handler.py
+++ b/tests/unit/test_plot_handler.py
@@ -20,10 +20,10 @@ class TestPlotHandler(unittest.TestCase):
             ["2021-01-01", "2021-12-31"], mock_experiment.models, mock_experiment.registry
         )
 
-    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.close")
     @patch("floatcsep.postprocess.plot_handler.parse_plot_config")
     @patch("floatcsep.postprocess.plot_handler.parse_projection")
-    def test_plot_forecasts(self, mock_parse_projection, mock_parse_plot_config, mock_savefig):
+    def test_plot_forecasts(self, mock_parse_projection, mock_parse_plot_config, mock_close):
         mock_experiment = MagicMock()
         mock_model = MagicMock()
         mock_experiment.models = [mock_model]
@@ -39,9 +39,9 @@ class TestPlotHandler(unittest.TestCase):
         mock_model.get_forecast().plot.assert_called()
 
         # Verify that pyplot.savefig was called to save the plot
-        mock_savefig.assert_called()
+        mock_close.assert_called()
 
-    @patch("matplotlib.pyplot.Figure.savefig")  # Mocking savefig on the Figure object
+    @patch("matplotlib.pyplot.Figure.savefig")
     @patch("floatcsep.postprocess.plot_handler.parse_plot_config")
     @patch("floatcsep.postprocess.plot_handler.parse_projection")
     def test_plot_catalogs(self, mock_parse_projection, mock_parse_plot_config, mock_savefig):
@@ -54,6 +54,8 @@ class TestPlotHandler(unittest.TestCase):
 
         mock_experiment.catalog_repo.filter_catalog = MagicMock(return_value=mock_catalog)
         mock_catalog.plot = mock_plot
+        mock_catalog.get_datetimes = MagicMock(return_value=["2021-01-01", "2021-12-31"])
+        mock_catalog.data = {"magnitude": [1, 2]}
         mock_plot.return_value = mock_ax
         mock_ax.get_figure.return_value = mock_figure
 
@@ -71,7 +73,9 @@ class TestPlotHandler(unittest.TestCase):
             plot_args=mock_parse_plot_config.return_value,
         )
 
-        mock_figure.savefig.assert_called_once_with("cat.png", dpi=300)
+        mock_figure.savefig.assert_called_once_with(
+            "cat.png", dpi=300, bbox_inches="tight", pad_inches=0.02, facecolor="white"
+        )
 
         mock_savefig.assert_called()
 

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -20,13 +20,15 @@ class TestReporting(unittest.TestCase):
         # Assert that custom_report was called with the experiment
         mock_custom_report.assert_called_once_with("custom_report_function", mock_experiment)
 
+    @patch("floatcsep.postprocess.reporting.MarkdownPdf")
     @patch("floatcsep.postprocess.reporting.MarkdownReport")
-    def test_generate_standard_report(self, mock_markdown_report):
+    def test_generate_standard_report(self, mock_markdown_report, mock_markdown_pdf):
         # Mock experiment without a custom report function
         mock_experiment = MagicMock()
-        mock_experiment.postprocess.get.return_value = None
+        mock_experiment.postprocess.get.return_value = {}
         mock_experiment.registry.get_figure_key.return_value = "figure_path"
         mock_experiment.magnitudes = [0, 1]
+        mock_experiment.time_windows = [[1, 2]]
         # Call the generate_report function
         reporting.generate_report(mock_experiment)
 
@@ -52,11 +54,11 @@ class TestMarkdownReport(unittest.TestCase):
 
     def test_save_report(self):
         report = reporting.MarkdownReport()
-        report.markdown = [["# Test Title\n", "Some content\n"]]
+        report.markdown = ["# Test Title\n", "Some content\n"]
         with patch("builtins.open", unittest.mock.mock_open()) as mock_file:
             report.save("/path/to/save/report.md")
-            mock_file.assert_called_with("/path/to/save/report.md", "w")
-            mock_file().writelines.assert_called_with(["# Test Title\n", "Some content\n"])
+            mock_file.assert_called_with("/path/to/save/report.md", "w", encoding="utf-8")
+            mock_file().write.assert_called_with("# Test Title\nSome content\n")
 
 
 if __name__ == "__main__":

--- a/tutorials/case_a/best_model.dat
+++ b/tutorials/case_a/best_model.dat
@@ -1,3 +1,3 @@
 # lon_min lon_max lat_min lat_max depth_min depth_max mag_min mag_max rate
-0 1 0 1 0 70 6 8 5e-1 1
-1 2 0 1 0 70 6 8 5e-1 0.1
+0 1 0 1 0 70 6 8 1.5 1
+1 2 0 1 0 70 6 8 0.5 1

--- a/tutorials/case_a/config.yml
+++ b/tutorials/case_a/config.yml
@@ -24,5 +24,4 @@ tests:
 
 postprocess:
   plot_forecasts:
-    cmap: magma
     catalog: True

--- a/tutorials/case_d/config.yml
+++ b/tutorials/case_d/config.yml
@@ -14,3 +14,6 @@ region_config:
 catalog: query_gcmt
 models: models.yml
 test_config: tests.yml
+
+postprocess:
+  plot_forecasts: False

--- a/tutorials/case_e/config.yml
+++ b/tutorials/case_e/config.yml
@@ -19,10 +19,12 @@ models: models.yml
 test_config: tests.yml
 
 postprocess:
+  plot_catalog:
+    markercolor: blue
   plot_forecasts:
     cmap: magma
     region_border: True
-    basemap: stock_img
+    basemap: ESRI_terrain
     clabel_fontsize: 14
     cticks_fontsize: 12
     alpha_exp: 0.8

--- a/tutorials/case_f/config.yml
+++ b/tutorials/case_f/config.yml
@@ -17,3 +17,6 @@ region_config:
 catalog: catalog.json
 model_config: models.yml
 test_config: tests.yml
+
+postprocess:
+  plot_forecasts: True

--- a/tutorials/case_g/models.yml
+++ b/tutorials/case_g/models.yml
@@ -4,4 +4,5 @@
     func_kwargs:
       n_sims: 100
       mag_min: 3.5
+      seed: 23
     build: venv

--- a/tutorials/case_i/config.yml
+++ b/tutorials/case_i/config.yml
@@ -8,7 +8,7 @@ time_config:
 
 region_config:
   region: nz_csep_region
-  mag_min: 4.0
+  mag_min: 3.0
   mag_max: 8.0
   mag_bin: 0.1
   depth_min: 0

--- a/tutorials/case_i/models.yml
+++ b/tutorials/case_i/models.yml
@@ -6,17 +6,15 @@
     path: models/step
     args_file: step_config.yaml
     build: docker
-    force_stage: true
-    force_build: true
     func: run
     func_kwargs:
       paths:
         catalog_file: catalog.csv
       forecast:
-        min_magnitude: 4.0
+        min_magnitude: 3.0
         region_code: 90
         parameters:
-          a_value: 0
+          a_value: -1.00
           b_value: 1.03
           p_value: 1.07
           c_value: 0.04

--- a/tutorials/case_j/config.yml
+++ b/tutorials/case_j/config.yml
@@ -15,11 +15,11 @@ region_config:
   depth_max: 70
 
 run_mode: parallel
+
 force_rerun: True
 catalog: catalog.csv
 model_config: models.yml
 test_config: tests.yml
 
 postprocess:
-  plot_catalog: false
   plot_forecasts: false

--- a/tutorials/case_j/models.yml
+++ b/tutorials/case_j/models.yml
@@ -1,7 +1,6 @@
 - pymock:
     path: pymock
     func: pymock
-    force_build: true
     func_kwargs:
       n_sims: 1000
       mag_min: 3.5
@@ -10,7 +9,6 @@
     path: pymock_slow
     func: pymock
     prefix: pymock
-    force_build: true
     func_kwargs:
       n_sims: 1000
       mag_min: 3.5


### PR DESCRIPTION
ft: added markdown-pdf to write a pdf report. Improved magnitude_vs_t…ime plot. Better control of figure sizes and margins when plotting with pycsep functions. Revamped the reporting module, can write forecasts and tests for all time windows checked margins and indent levels. Modified the figure size placement onto the markdown.
fix: catalog forecasts are now loaded with a name. Plot forecasts now correctly parses its arguments when plotting alongside a catalog
tutorials: modified many configurations for better plotting. Removed some forced builds and added seed to pymock models.
build: added markdown-pdf as requirement