### PR TITLE
Support for python 3.12 and improved conda environment manager

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,33 +14,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v4.2.2
-    - uses: mamba-org/setup-micromamba@v1
-      with:
-        generate-run-shell: true
-        environment-file: environment.yml
-        create-args: >-
-          python=${{ matrix.python-version }}
+      - uses: actions/checkout@v4.2.2
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          generate-run-shell: true
+          environment-file: environment.yml
+          create-args: >-
+            python=${{ matrix.python-version }}
 
-    - name: Install floatCSEP
-      run: |
-        pip install -e .[dev]
-        python -c "import floatcsep; print('Version: ', floatcsep.__version__)"
+      - name: Install floatCSEP
+        run: |
+          pip install -e .[dev]
+          python -c "import floatcsep; print('Version: ', floatcsep.__version__)"
 
-    - name: Test with pytest
-      run: |
-        pytest --durations=0
+      - name: Test with pytest
+        run: |
+          pytest --durations=0
 
-    - name: Upload coverage
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false
+      - name: Upload coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 .. important::
 
-    This application uses ``3.9 <= python <= 3.11``
+    This application uses ``3.9 <= python <= 3.12``
 
 
 Latest Version
@@ -25,8 +25,8 @@ Then, let ``conda`` automatically install all required dependencies of **floatCS
 
     .. code-block:: console
 
-        $ conda create -n csep_env
-        $ conda activate csep_env
+        $ conda env create -f environment.yml
+        $ conda activate floatcsep
 
 .. note::
 
@@ -47,6 +47,7 @@ Lastly, install **floatCSEP** into the new environment using ``pip``:
 
         .. code-block:: console
 
+            $ git pull
             $ conda env update --file environment.yml
             $ pip install . -U
 
@@ -76,10 +77,11 @@ Having a ``conda`` manager installed (see **Note** box above), type in a console
 
     .. code-block:: console
 
-        $ conda create -n csep_env
-        $ conda activate csep_env
+        $ conda create -n experiment python={PYTHON_VERSION}
+        $ conda activate experiment
         $ conda install -c conda-forge floatcsep
 
+where ``3.9 < {PYTHON_VERSION} <= 3.12`` is at your convenience.
 
 2. From the ``PyPI`` repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -111,10 +113,10 @@ It is recommended (not obligatory) to use a ``conda`` environment to make sure y
 
     .. code-block:: console
 
-        $ conda create -n csep_dev
-        $ conda activate csep_dev
+        $ conda create -n floatcsep_dev
+        $ conda activate floatcsep_dev
         $ git clone https://github.com/${your_fork}/floatcsep
         $ cd floatcsep
-        $ pip install .[dev]
+        $ pip install -e .[dev]
 
 This will install and configure all the unit-testing, linting, and documentation packages.

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python <= 3.11
+  - python <= 3.12
   - numpy
   - pycsep
   - dateparser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ license-files = ["LICENSE"]
 authors = [
     { name = "Pablo Iturrieta", email = "pciturri@gfz-potsdam.de" },
 ]
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "numpy",
@@ -80,7 +81,7 @@ testpaths = [
 [tool.black]
 line-length = 96
 skip-string-normalization = false
-target-version = ["py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.flake8]
 ignore = ["E203", "W503", "F401"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.11
 envlist =
-    {py39,py310,py311}
+    {py39,py310,py311,py312}
 isolated_build = true
 requires = tox-conda
 

--- a/tutorials/case_g/pymock/pyproject.toml
+++ b/tutorials/case_g/pymock/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=52.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/tutorials/case_g/pymock/setup.cfg
+++ b/tutorials/case_g/pymock/setup.cfg
@@ -16,7 +16,7 @@ packages =
 install_requires =
     numpy
     matplotlib
-python_requires = >=3.7
+python_requires = >=3.9, <3.13
 zip_safe = no
 
 [options.entry_points]


### PR DESCRIPTION
Closes #42 

ft: improved conda environment manager, which handles now if or not e…nvironment.yml is present, retrieving version from python build files, and decide better with which python should the conda env be created. Improved venv handler when it is run from conda/floatcsep.

build: provided support for py3.12
docs: updated installation instructions
tests: updated all unit tests