### PR TITLE
Removed case_d test from CI

### DIFF
--- a/tests/e2e/test_data.py
+++ b/tests/e2e/test_data.py
@@ -68,6 +68,7 @@ class RunExamples(DataTest):
         self.run_evaluation(cfg)
         self.assertEqual(1, 1)
 
+    @skip_on_ci("Tested only locally")
     def test_case_d(self, *args):
 
         try:


### PR DESCRIPTION
tests: skip case_d on CI, due to network issues with Zenodo with CI workflow for multiple OS/python versions.