### PR TITLE
Updated citation info/metadata to match JOSS publication

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,12 +6,15 @@
   "language": "eng",
   "keywords": [
     "Python",
-    "seismology",
+    "statistical seismology",
+    "earthquake catalog",
     "earthquake forecasting",
+    "forecast models",
     "forecast testing",
+    "forecast evaluation",
     "CSEP"
   ],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "creators": [
     {
       "name": "Iturrieta, Pablo",
@@ -101,7 +104,8 @@
     }
   ],
   "grants": [
-    { "id": "10.13039/501100000780::101058518" }
+    { "id": "10.13039/501100000780::101058518" },
+    { "id": "10.13039/501100000780::821115" }
   ],
   "related_identifiers": [
     {
@@ -113,6 +117,11 @@
       "identifier": "https://floatcsep.readthedocs.io",
       "relation": "isDocumentedBy",
       "resource_type": "other"
+    },
+    {
+      "identifier": "https://doi.org/10.21105/joss.09408",
+      "relation": "isPublishedIn",
+      "resource_type": "publication-article"
     }
   ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,33 +1,114 @@
-cff-version: 1.2.0
-message: "If you use floatCSEP in your research, please cite the Zenodo release."
-title: "floatCSEP: An application to deploy and conduct reproducible prospective earthquake forecasting experiments"
+cff-version: "1.2.0"
+message: If you use this software, please cite our article in the
+  Journal of Open Source Software.
+
+preferred-citation:
+  authors:
+    - family-names: Iturrieta
+      given-names: Pablo
+      orcid: "https://orcid.org/0000-0002-4787-1343"
+      affiliation: "GFZ Helmholtz Centre for Geosciences, Potsdam, Germany"
+    - family-names: Savran
+      given-names: "William H."
+      orcid: "https://orcid.org/0000-0001-5404-0778"
+      affiliation: "University of Nevada, Reno, United States"
+    - family-names: Herrmann
+      given-names: Marcus
+      orcid: "https://orcid.org/0000-0002-2342-1970"
+      affiliation: "Università degli Studi di Napoli Federico II, Naples, Italy"
+    - family-names: Bayona
+      given-names: "José A."
+      orcid: "https://orcid.org/0000-0002-3026-0327"
+      affiliation: "School of Earth Sciences, University of Bristol, Bristol, United Kingdom"
+    - family-names: Gerstenberger
+      given-names: "Matt C."
+      orcid: "https://orcid.org/0000-0002-2938-1359"
+      affiliation: "GNS Science | Te Pū Ao, Lower Hutt, New Zealand"
+    - family-names: Graham
+      given-names: "Kenny M."
+      orcid: "https://orcid.org/0000-0003-3645-6344"
+      affiliation: "GNS Science | Te Pū Ao, Lower Hutt, New Zealand"
+    - family-names: Maechling
+      given-names: "Philip J."
+      orcid: "https://orcid.org/0000-0002-9221-7068"
+      affiliation: "Southern California Earthquake Center, University of Southern California, United States"
+    - family-names: Marzocchi
+      given-names: Warner
+      orcid: "https://orcid.org/0000-0002-9114-1516"
+      affiliation: "Università degli Studi di Napoli Federico II, Naples, Italy"
+    - family-names: Mizrahi
+      given-names: Leila
+      orcid: "https://orcid.org/0000-0002-5262-3168"
+      affiliation: "Swiss Seismological Service at ETH Zürich, Zürich, Switzerland"
+    - family-names: Schorlemmer
+      given-names: Danijel
+      orcid: "https://orcid.org/0000-0003-3969-1059"
+      affiliation: "GFZ Helmholtz Centre for Geosciences, Potsdam, Germany; Swiss Seismological Service at ETH Zürich, Zürich, Switzerland"
+    - family-names: Serafini
+      given-names: Francesco
+      orcid: "https://orcid.org/0000-0003-0154-6200"
+      affiliation: "School of Earth Sciences, University of Bristol, Bristol, United Kingdom"
+    - family-names: Silva
+      given-names: Fabio
+      orcid: "https://orcid.org/0000-0002-6543-5705"
+      affiliation: "Southern California Earthquake Center, University of Southern California, United States"
+    - family-names: Werner
+      given-names: Maximilian J."
+      orcid: "https://orcid.org/0000-0002-2430-2631"
+      affiliation: "School of Earth Sciences, University of Bristol, Bristol, United Kingdom"
+  date-published: 2026-02-20
+  doi: 10.21105/joss.09408
+  issn: 2475-9066
+  issue: 118
+  journal: Journal of Open Source Software
+  publisher:
+    name: Open Journals
+  start: 9408
+  title: "floatCSEP: An application to deploy and conduct reproducible
+    prospective earthquake forecasting experiments"
+  type: article
+  url: "https://joss.theoj.org/papers/10.21105/joss.09408"
+  volume: 11
+
+title: "floatCSEP: An application to deploy and conduct reproducible
+  prospective earthquake forecasting experiments"
 type: software
-license: "BSD-3-Clause"
-
 repository-code: "https://github.com/cseptesting/floatcsep"
-url: "https://floatcsep.readthedocs.io"
-
-version: "0.3.0"
-doi: "10.5281/zenodo.15576250"
-publisher: "Zenodo"
-
+license: "BSD-3-Clause"
+keywords:
+    - Python
+    - "statistical seismology"
+    - "earthquake catalog"
+    - "earthquake forecasting"
+    - "forecast models"
+    - "forecast testing"
+    - "forecast evaluation"
+    - CSEP
+identifiers:
+  - type: url
+    value: "https://floatcsep.readthedocs.io"
+    description: "The website containing the documentation of floatCSEP."
+  - type: doi
+    value: 10.5281/zenodo.7953816
+    description: "The Zenodo concept DOI - archived snapshots of selected floatCSEP versions."
 authors:
-  - family-names: "Iturrieta"
-    given-names: "Pablo"
+  - family-names: Iturrieta
+    given-names: Pablo
     orcid: "https://orcid.org/0000-0002-4787-1343"
     affiliation: "GFZ Helmholtz Centre for Geosciences, Potsdam, Germany"
-
-  - family-names: "Khawaja"
+  - family-names: Khawaja
     given-names: "Asim M."
     orcid: "https://orcid.org/0000-0002-6196-4503"
     affiliation: "GFZ Helmholtz Centre for Geosciences, Potsdam, Germany"
-
-  - family-names: "Savran"
+  - family-names: Savran
     given-names: "William H."
     orcid: "https://orcid.org/0000-0001-5404-0778"
     affiliation: "University of Nevada, Reno, United States"
-
-  - family-names: "Schorlemmer"
-    given-names: "Danijel"
+  - family-names: Schorlemmer
+    given-names: Danijel
     orcid: "https://orcid.org/0000-0003-3969-1059"
     affiliation: "GFZ Helmholtz Centre for Geosciences, Potsdam, Germany; Swiss Seismological Service at ETH Zürich, Zürich, Switzerland"
+contact:
+- family-names: Iturrieta
+  given-names: Pablo
+  email: pciturri@gfz-potsdam.de

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSEP Floating Experiments
 
-<img src="https://i.postimg.cc/6p5krRnB/float-CSEP-Logo-CMYK.png" width="320"> 
+<img src="https://i.postimg.cc/6p5krRnB/float-CSEP-Logo-CMYK.png" width="320">
 
 **An application to deploy and conduct reproducible prospective earthquake forecasting experiments**
 
@@ -12,8 +12,8 @@
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/floatcsep)](https://anaconda.org/conda-forge/floatcsep)
 [![Python Versions](https://img.shields.io/pypi/pyversions/floatcsep)](https://pypi.org/project/floatcsep/)
 [![Code Coverage](https://codecov.io/gh/cseptesting/floatcsep/branch/main/graph/badge.svg?token=LI4RSDOKA1)](https://codecov.io/gh/cseptesting/floatcsep)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.09408/status.svg)](https://doi.org/10.21105/joss.09408)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7953816.svg)](https://doi.org/10.5281/zenodo.7953816)
-
 
 </p>
 
@@ -82,7 +82,7 @@ visualized in `results/report.md`, `results/report.pdf` or in a dashboard with:
 floatcsep view config.yml
 ```
 
-**Check out the experiment, models and tests definition in the tutorials [documentation](https://floatcsep.readthedocs.io/en/latest/tutorials/case_a.html)** or in the configuration files for each case in ``floatcsep/tutorials/``. 
+**Check out the experiment, models and tests definition in the tutorials [documentation](https://floatcsep.readthedocs.io/en/latest/tutorials/case_a.html)** or in the configuration files for each case in ``floatcsep/tutorials/``.
 
 # Important Links
 
@@ -118,17 +118,17 @@ information.
 
 If you use **floatCSEP** in your work, please cite it using the **“Cite this repository”** link on the right side of the GitHub page or with:
 
-> Iturrieta, P., Khawaja, A. M., Savran, W. H., & Schorlemmer, D. (2025). floatCSEP: An application to deploy and conduct reproducible and prospective earthquake forecasting (Version 0.3.0) [Computer software]. Zenodo. https://doi.org/10.5281/zenodo.15576250
+> Iturrieta, P., Savran, W. H., Herrmann, M., Bayona, J. A., Gerstenberger, M. C., Graham, K. M., Maechling, P. J., Marzocchi, W., Mizrahi, L., Schorlemmer, D., Serafini, F., Silva, F., & Werner, M. J. (2026). floatCSEP: An application to deploy and conduct reproducible prospective earthquake forecasting experiments. _Journal of Open Source Software, 11_(118). 9408. doi: [10.21105/joss.09408](https://doi.org/10.21105/joss.09408)
 
 # Support
-     
+
 | <img src="https://i.postimg.cc/rFKQ0vRL/GFZ-Wortbildmarke-EN-Helmholtzdunkelblau-RGB.png" alt="GFZ logo" height="50"/> | <img src="https://i.postimg.cc/CLc5tQcZ/Geo-INQUIRE-logo.png" alt="GeoInquire logo" height="72"/> | <img src="https://i.postimg.cc/tC1LdjYf/scec.png" alt="SCEC logo" height="90"/> |
 |:----------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------:|
 
 
 - The work in this repository has received funding from the European Union’s Horizon research and innovation programme under grant agreements No.s 101058518 and 821115 of the projects [GeoInquire](https://www.geo-inquire.eu/) and [RISE](https://www.rise-eu.org/).
-  
-- This research was supported by the [Statewide California Earthquake Center](https://www.scec.org/).  
+
+- This research was supported by the [Statewide California Earthquake Center](https://www.scec.org/).
   SCEC is funded by NSF Cooperative Agreement EAR-2225216 and USGS Cooperative Agreement G24AC00072-00.
 
 


### PR DESCRIPTION
In `CITATION.cff`:
* I left the original four authors - @pabloitu: not sure if we want to align it with the JOSS paper, but it would be redundant with the following:
* added a `preferred-citation` as suggested in the [JOSS REVIEW thread](https://github.com/openjournals/joss-reviews/issues/9408#issuecomment-3936714721) featuring **all authors** (copied from [this former commit](https://github.com/cseptesting/floatcsep/commit/7df4a1160af2a1c0d503af6620b37bc3bcbd790e)); see also https://github.com/cseptesting/floatcsep/issues/109#issuecomment-3700586756
* added a few more metadata (from [CITATION.cff docs](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md)): identifiers (to Zenodo & floatCSEP docs), keywords (extended from Zenodo json), and contact
* removed version metadata (not needed, as we prefer the JOSS citation)
* structured everything (first preferred citation, then general metadata)

In `README`:
* added JOSS badge as provided in the [JOSS REVIEW thread](https://github.com/openjournals/joss-reviews/issues/9408#issuecomment-3936761575)
* updated citation in **How to cite**

In `.zenodo.json`:
* linked JOSS DOI (`isPublishedIn`)
* updated version, keywords, & grants

Closes #126